### PR TITLE
Update to Muscle V5 input

### DIFF
--- a/plipify/fingerprints.py
+++ b/plipify/fingerprints.py
@@ -6,7 +6,7 @@ Factories that take a Structure or multiple structures and produce
 an interaction fingerprint.
 
 """
-
+import subprocess
 from collections import defaultdict, Counter
 from tempfile import TemporaryDirectory
 from pathlib import Path
@@ -14,7 +14,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from Bio.AlignIO.FastaIO import MultipleSeqAlignment, Seq, SeqRecord
-from Bio.Align.Applications import MuscleCommandline
 from Bio.AlignIO import write as write_alignment, read as read_alignment
 
 from .core import ProteinResidue
@@ -244,8 +243,12 @@ class InteractionFingerprint:
             outfile = str(tmp / "out.fasta")
             logfile = str(tmp / "log.txt")
             write_alignment(unaligned, infile, "fasta")
-            cli = MuscleCommandline(input=infile, out=outfile, diags=True, maxiters=5, log=logfile)
-            cli()
+            cli = f"muscle -super5 {infile} -output {outfile} -log {logfile}"
+            subprocess.call(cmd,
+                            shell=True,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.STDOUT
+                            )
             aligned = read_alignment(outfile, "fasta")
 
         offset = unaligned.get_alignment_length() - aligned.get_alignment_length()


### PR DESCRIPTION
## Description
Update Muscle V5 command line. `Bio.Align.Applications.MuscleCommandline` failed to run because it deploys Muscle V3 args, and by default Muscle v5 us installed.

## Todos
  - [x] Updated putdated args to `-super5` and `-output` in [this line.](https://github.com/volkamerlab/plipify/blob/c7b68bbf325aac904969867c7fbed5179f9670b7/plipify/fingerprints.py#L247)
## Status
- [x] Ready to go